### PR TITLE
Fix import order in admin UI

### DIFF
--- a/src/ui/admin_interface.py
+++ b/src/ui/admin_interface.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Admin interface for Receiving & Shipping Tracker."""
+
+from __future__ import annotations
 
 import csv
 import hashlib


### PR DESCRIPTION
## Summary
- move the admin interface module docstring before the `from __future__` import

## Testing
- `ruff check src/ui/admin_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_684c4fc7e0ec83268947c0b7afb30a76