### PR TITLE
Add pytest test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,78 @@
+import sys
+import types
+import sqlite3
+import hashlib
+import os
+import tempfile
+import pytest
+
+from database.init_db import initialize_database
+
+# Fixture to create a temporary database using the provided schema
+@pytest.fixture()
+def temp_db(tmp_path):
+    db_path = tmp_path / 'test.db'
+    initialize_database(str(db_path))
+    yield str(db_path)
+
+# Fixture to replace customtkinter and tkinter.messagebox with dummies so GUI
+# components can be instantiated in a headless test environment
+@pytest.fixture(autouse=True)
+def dummy_gui(monkeypatch):
+    dummy = types.ModuleType('customtkinter')
+
+    class DummyVar:
+        def __init__(self, value=None):
+            self._value = value
+        def get(self):
+            return self._value
+        def set(self, value):
+            self._value = value
+
+    class DummyWidget:
+        def __init__(self, *a, **kw):
+            pass
+        def pack(self, *a, **kw):
+            pass
+        def bind(self, *a, **kw):
+            pass
+        def configure(self, *a, **kw):
+            pass
+        def set(self, *a, **kw):
+            pass
+        def destroy(self, *a, **kw):
+            pass
+        def winfo_children(self):
+            return []
+        def focus_set(self):
+            pass
+
+    class DummyCTk(DummyWidget):
+        def title(self, *a, **kw):
+            pass
+        def geometry(self, *a, **kw):
+            pass
+        def destroy(self, *a, **kw):
+            pass
+
+    dummy.CTk = DummyCTk
+    dummy.CTkLabel = DummyWidget
+    dummy.CTkEntry = DummyWidget
+    dummy.CTkOptionMenu = DummyWidget
+    dummy.CTkFrame = DummyWidget
+    dummy.CTkProgressBar = DummyWidget
+    dummy.CTkButton = DummyWidget
+    dummy.IntVar = DummyVar
+    dummy.StringVar = DummyVar
+    dummy.set_appearance_mode = lambda *a, **kw: None
+
+    monkeypatch.setitem(sys.modules, 'customtkinter', dummy)
+
+    mb = types.SimpleNamespace(
+        showinfo=lambda *a, **kw: None,
+        showwarning=lambda *a, **kw: None,
+        showerror=lambda *a, **kw: None,
+    )
+    monkeypatch.setitem(sys.modules, 'tkinter.messagebox', mb)
+    yield
+

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,35 @@
+import sqlite3
+import hashlib
+
+from src.ui import login
+
+
+def add_user(db_path, username='test', password='pw', role='ADMIN'):
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    hashed = hashlib.sha256(password.encode()).hexdigest()
+    cur.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+        (username, hashed, role),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_authenticate_and_session_flow(temp_db):
+    add_user(temp_db)
+
+    user = login.authenticate_user('test', 'pw', temp_db)
+    assert user is not None
+    assert user[1] == 'test'
+
+    session_id = login.create_session(user[0], temp_db)
+    assert isinstance(session_id, int)
+
+    login.end_session(session_id, temp_db)
+    conn = sqlite3.connect(temp_db)
+    cur = conn.cursor()
+    cur.execute('SELECT end_time FROM scan_sessions WHERE session_id=?', (session_id,))
+    end_time = cur.fetchone()[0]
+    conn.close()
+    assert end_time is not None

--- a/tests/test_shipper_window.py
+++ b/tests/test_shipper_window.py
@@ -1,0 +1,47 @@
+import sqlite3
+
+import pytest
+
+
+def setup_waybill(db_path):
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
+        " VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '2024-01-01')"
+    )
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
+        " VALUES ('WB1', 'P1', 10, 'DRV-RM', '', '', 0, '2024-01-01')"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_process_scan_allocation(temp_db, monkeypatch):
+    setup_waybill(temp_db)
+
+    # Import here after dummy_gui fixture patched customtkinter
+    from src.ui import scanner_interface
+
+    # patch finish_session to avoid touching GUI
+    monkeypatch.setattr(scanner_interface.ShipperWindow, '_finish_session', lambda self: None)
+
+    window = scanner_interface.ShipperWindow(user_id=1, db_path=temp_db)
+
+    # Set quantity and scan code
+    window.qty_var.set(6)
+    window.scan_var.set('P1')
+    window.process_scan()
+
+    amoline = [l for l in window.lines if 'AMO' in l.subinv][0]
+    kanbanline = [l for l in window.lines if 'AMO' not in l.subinv][0]
+    assert amoline.scanned == 5
+    assert kanbanline.scanned == 1
+
+    conn = sqlite3.connect(temp_db)
+    cur = conn.cursor()
+    cur.execute('SELECT scanned_qty FROM scan_events')
+    qty = cur.fetchone()[0]
+    conn.close()
+    assert qty == 6

--- a/tests/test_waybill_import.py
+++ b/tests/test_waybill_import.py
@@ -1,0 +1,14 @@
+import sqlite3
+from src.logic import waybill_import
+
+
+def test_import_waybill(temp_db):
+    inserted = waybill_import.import_waybill('data/wb sample.xlsx', temp_db)
+    assert inserted == 18
+
+    conn = sqlite3.connect(temp_db)
+    cur = conn.cursor()
+    cur.execute('SELECT COUNT(*) FROM waybill_lines')
+    count = cur.fetchone()[0]
+    conn.close()
+    assert count == 18


### PR DESCRIPTION
## Summary
- add pytest fixtures and dummy GUI components
- test waybill import logic
- test login/auth flow
- basic ShipperWindow quantity allocation test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4fd63c548326b3dfb645c1f17ffe