### PR TITLE
Improve login loop and shipper info

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -13,20 +13,21 @@ from src.ui.scanner_interface import start_shipper_interface
 def main() -> None:
     """Prompt for login and launch the appropriate interface."""
 
-    login_info = prompt_login()
-    if login_info is None:
-        print("Login cancelled")
-        return
+    while True:
+        login_info = prompt_login()
+        if login_info is None:
+            print("Login cancelled")
+            break
 
-    session_id, user_id, _username, role = login_info
+        session_id, user_id, _username, role = login_info
 
-    try:
-        if role.upper() == "ADMIN":
-            start_admin_interface()
-        else:
-            start_shipper_interface(user_id)
-    finally:
-        end_session(session_id)
+        try:
+            if role.upper() == "ADMIN":
+                start_admin_interface()
+            else:
+                start_shipper_interface(user_id)
+        finally:
+            end_session(session_id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reopen login form after closing any interface
- display last scan information in shipper window
- only finish shipper session when all waybills complete

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c787821a48326a43a56002a2c7250