### PR TITLE
Add waybill tracking column and update scan logic

### DIFF
--- a/database/migrate.py
+++ b/database/migrate.py
@@ -1,0 +1,38 @@
+import sqlite3
+from typing import Optional
+
+
+def add_waybill_number_column(db_path: str = "receiving_tracker.db") -> None:
+    """Add waybill_number columns to existing DB if they don't exist."""
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+
+    cur.execute("PRAGMA table_info(scan_events)")
+    columns = [row[1] for row in cur.fetchall()]
+    if "waybill_number" not in columns:
+        cur.execute("ALTER TABLE scan_events ADD COLUMN waybill_number TEXT NOT NULL DEFAULT ''")
+        cur.execute(
+            "UPDATE scan_events SET waybill_number=(SELECT waybill_number FROM scan_sessions WHERE scan_sessions.session_id=scan_events.session_id)"
+        )
+        conn.commit()
+
+    cur.execute("PRAGMA table_info(scan_summary)")
+    columns = [row[1] for row in cur.fetchall()]
+    if "waybill_number" not in columns:
+        cur.execute("ALTER TABLE scan_summary ADD COLUMN waybill_number TEXT NOT NULL DEFAULT ''")
+        cur.execute(
+            "UPDATE scan_summary SET waybill_number=(SELECT waybill_number FROM scan_sessions WHERE scan_sessions.session_id=scan_summary.session_id)"
+        )
+        conn.commit()
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Migrate database for waybill columns")
+    parser.add_argument("db_path", nargs="?", default="receiving_tracker.db")
+    args = parser.parse_args()
+    add_waybill_number_column(args.db_path)
+    print("Migration complete")

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS scan_sessions (
 CREATE TABLE IF NOT EXISTS scan_events (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id INTEGER NOT NULL,
+    waybill_number TEXT NOT NULL DEFAULT '',
     part_number TEXT NOT NULL,
     scanned_qty INTEGER NOT NULL,
     timestamp TEXT NOT NULL,
@@ -52,6 +53,7 @@ CREATE TABLE IF NOT EXISTS scan_events (
 CREATE TABLE IF NOT EXISTS scan_summary (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id INTEGER NOT NULL,
+    waybill_number TEXT NOT NULL DEFAULT '',
     user_id INTEGER NOT NULL,
     part_number TEXT NOT NULL,
     total_scanned INTEGER,

--- a/src/ui/admin_interface.py
+++ b/src/ui/admin_interface.py
@@ -101,10 +101,9 @@ def query_scan_summary(
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
     query = (
-        "SELECT se.waybill_number, u.username, s.part_number, s.total_scanned, "
+        "SELECT s.waybill_number, u.username, s.part_number, s.total_scanned, "
         "s.expected_qty, s.remaining_qty, s.allocated_to, s.reception_date "
         "FROM scan_summary s "
-        "JOIN scan_sessions se ON se.session_id = s.session_id "
         "JOIN users u ON u.user_id = s.user_id WHERE 1=1"
     )
     params: list[object] = []
@@ -115,7 +114,7 @@ def query_scan_summary(
         query += " AND s.reception_date=?"
         params.append(date)
     if waybill:
-        query += " AND se.waybill_number=?"
+        query += " AND s.waybill_number=?"
         params.append(waybill)
     cur.execute(query, params)
     rows = cur.fetchall()

--- a/tests/test_shipper_window.py
+++ b/tests/test_shipper_window.py
@@ -14,6 +14,10 @@ def setup_waybill(db_path):
         "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
         " VALUES ('WB1', 'P1', 10, 'DRV-RM', '', '', 0, '2024-01-01')"
     )
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
+        " VALUES ('WB2', 'P1', 5, 'DRV-AMO', '', '', 0, '2024-01-01')"
+    )
     conn.commit()
     conn.close()
 
@@ -41,7 +45,46 @@ def test_process_scan_allocation(temp_db, monkeypatch):
 
     conn = sqlite3.connect(temp_db)
     cur = conn.cursor()
-    cur.execute('SELECT scanned_qty FROM scan_events')
-    qty = cur.fetchone()[0]
+    cur.execute('SELECT scanned_qty, waybill_number FROM scan_events')
+    qty, waybill = cur.fetchone()
     conn.close()
     assert qty == 6
+    assert waybill == 'WB1'
+
+
+def test_waybill_switch_does_not_affect_previous_scans(temp_db, monkeypatch):
+    setup_waybill(temp_db)
+
+    from src.ui import scanner_interface
+
+    monkeypatch.setattr(scanner_interface.ShipperWindow, '_finish_session', lambda self: None)
+
+    window = scanner_interface.ShipperWindow(user_id=1, db_path=temp_db)
+
+    window.qty_var.set(2)
+    window.scan_var.set('P1')
+    window.process_scan()
+
+    # switch to second waybill and scan again
+    window.waybill_var.set('WB2')
+    window.load_waybill('WB2')
+    window.qty_var.set(3)
+    window.scan_var.set('P1')
+    window.process_scan()
+
+    # verify scans for WB1 remain
+    conn = sqlite3.connect(temp_db)
+    cur = conn.cursor()
+    cur.execute('SELECT SUM(scanned_qty) FROM scan_events WHERE waybill_number=?', ('WB1',))
+    wb1_qty = cur.fetchone()[0]
+    cur.execute('SELECT SUM(scanned_qty) FROM scan_events WHERE waybill_number=?', ('WB2',))
+    wb2_qty = cur.fetchone()[0]
+    conn.close()
+
+    assert wb1_qty == 2
+    assert wb2_qty == 3
+
+    progress = window._get_waybill_progress()
+    remaining_dict = {wb: rem for wb, _, rem in progress}
+    assert remaining_dict['WB1'] == 13
+    assert remaining_dict['WB2'] == 2


### PR DESCRIPTION
## Summary
- add `waybill_number` column to `scan_events` and `scan_summary`
- store waybill number when inserting scan events
- update scan summary queries and progress logic to rely on event waybill numbers
- add migration utility for existing databases
- ensure tests cover switching waybills without corrupting previous data

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7e6430908326913ad3427f4bb188