### PR TITLE
Add file logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ receiving_tracker.db
 send_user.py
 reset_db.py
 man_entry_db.py
+tracker.log

--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ receiving_shipping_tracker/
 │   └── ui/                # UI layer (ex: Streamlit)
 ├── .gitignore
 └── README.md
+
+### Logs
+
+Runtime logs are written to `tracker.log` in the project root. This file is
+created automatically when the application starts.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,8 @@
+"""Package initialization and logging configuration."""
+
+from __future__ import annotations
+
+from .logging_utils import setup_logging
+
+# Configure logging on package import
+setup_logging()

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -1,0 +1,20 @@
+"""Logging configuration helpers for the application."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+
+LOG_FILE = Path(__file__).resolve().parent.parent / "tracker.log"
+
+
+def setup_logging() -> None:
+    """Configure :mod:`logging` to write messages to :data:`LOG_FILE`."""
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        handlers=[logging.FileHandler(LOG_FILE, encoding="utf-8")],
+    )
+

--- a/src/ui/admin_interface.py
+++ b/src/ui/admin_interface.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import csv
 import sqlite3
 from pathlib import Path
@@ -14,6 +16,8 @@ from src.logic import waybill_import
 
 from src.config import DB_PATH
 from src.data_manager import DataManager
+
+logger = logging.getLogger(__name__)
 
 #DB_PATH = "receiving_tracker.db"
 
@@ -125,8 +129,10 @@ class AdminWindow(ctk.CTk):
         try:
             inserted = import_waybill_file(path, self.db_path)
         except Exception as exc:  # noqa: BLE001
+            logger.exception("Waybill import failed: %s", path)
             messagebox.showerror("Import failed", str(exc))
             return
+        logger.info("Imported %s with %d lines", path, inserted)
         messagebox.showinfo(
             "Waybill imported", f"{inserted} lines inserted from {Path(path).name}"
         )

--- a/src/ui/login.py
+++ b/src/ui/login.py
@@ -9,6 +9,8 @@ new entry in the ``scan_sessions`` table.
 
 from __future__ import annotations
 
+import logging
+
 from typing import Optional, Tuple
 
 import customtkinter as ctk
@@ -16,6 +18,8 @@ from tkinter import messagebox
 
 from src.config import DB_PATH
 from src.data_manager import DataManager
+
+logger = logging.getLogger(__name__)
 
 #DB_PATH = "receiving_tracker.db"
 
@@ -77,8 +81,11 @@ class LoginWindow(ctk.CTk):
 
         user = authenticate_user(username, password, self.db_path)
         if user is None:
+            logger.warning("Login failed for user %s", username)
             messagebox.showerror("Login failed", "Invalid username or password")
             return
+
+        logger.info("User %s authenticated", username)
 
         session_id = create_session(user[0], self.db_path)
         # store result: (session_id, user_id, username, role)

--- a/src/ui/scanner_interface.py
+++ b/src/ui/scanner_interface.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from datetime import datetime
 from typing import Dict, List, Optional
 
@@ -18,6 +20,8 @@ from src.logic.scanning import Line, ScannerLogic
 
 #DB_PATH = "receiving_tracker.db"
 PART_IDENTIFIERS_CSV = "data/part_identifiers.csv"
+
+logger = logging.getLogger(__name__)
 
 
 def _color_from_ratio(ratio: float) -> str:
@@ -343,6 +347,7 @@ class ShipperWindow(ctk.CTk):
         try:
             allocations = self.logic.allocate(matching, qty)
         except ValueError:
+            logger.warning("Over scan detected for part %s (qty=%s)", part, qty)
             messagebox.showwarning("Over scan", "Quantity exceeds expected")
             self.scan_var.set("")
             self.qty_var.set(1)


### PR DESCRIPTION
## Summary
- configure a basic file logger in `logging_utils.py`
- hook logging setup during package import
- log waybill import failures and successes
- log login attempts and overscan warnings
- document the `tracker.log` file location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca34cc0e483268a0515c6754441fd