### PR TITLE
Batch insert for scan summaries

### DIFF
--- a/src/ui/scanner_interface.py
+++ b/src/ui/scanner_interface.py
@@ -198,6 +198,7 @@ class ShipperWindow(ctk.CTk):
 
     def _record_summary(self) -> None:
         scans = self._fetch_scans(self.waybill_var.get())
+        rows = []
         for part, total in scans.items():
             expected = sum(
                 line.qty_total for line in self.lines if line.part == part
@@ -206,17 +207,21 @@ class ShipperWindow(ctk.CTk):
             allocated = ", ".join(
                 f"{line.subinv}:{line.scanned}" for line in self.lines if line.part == part
             )
-            self.dm.insert_scan_summary(
-                self.session_id,
-                self.waybill_var.get(),
-                self.user_id,
-                part,
-                total,
-                expected,
-                remaining,
-                allocated,
-                datetime.utcnow().date().isoformat(),
+            rows.append(
+                (
+                    self.session_id,
+                    self.waybill_var.get(),
+                    self.user_id,
+                    part,
+                    total,
+                    expected,
+                    remaining,
+                    allocated,
+                    datetime.utcnow().date().isoformat(),
+                )
             )
+        if rows:
+            self.dm.insert_scan_summaries(rows)
 
     # Interface logic ------------------------------------------------
     def load_waybill(self, waybill: str) -> None:

--- a/tests/test_summary_insert.py
+++ b/tests/test_summary_insert.py
@@ -1,0 +1,67 @@
+import sqlite3
+import pytest
+
+
+def setup_waybill_multi(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
+        " VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '2024-01-01')"
+    )
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
+        " VALUES ('WB1', 'P2', 10, 'DRV-RM', '', '', 0, '2024-01-01')"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_record_summary_multiple_rows_single_call(temp_db, monkeypatch):
+    setup_waybill_multi(temp_db)
+
+    from src.ui import scanner_interface
+
+    monkeypatch.setattr(scanner_interface.ShipperWindow, "_finish_session", lambda self: None)
+
+    captured = []
+    orig_insert = scanner_interface.DataManager.insert_scan_summaries
+
+    def spy(self, rows):
+        captured.append(list(rows))
+        return orig_insert(self, rows)
+
+    monkeypatch.setattr(scanner_interface.DataManager, "insert_scan_summaries", spy)
+    monkeypatch.setattr(
+        scanner_interface.DataManager,
+        "insert_scan_summary",
+        lambda *a, **kw: pytest.fail("single insert used"),
+    )
+
+    window = scanner_interface.ShipperWindow(user_id=1, db_path=temp_db)
+
+    window.qty_var.set(2)
+    window.scan_var.set("P1")
+    window.process_scan()
+
+    window.qty_var.set(3)
+    window.scan_var.set("P2")
+    window.process_scan()
+
+    window._record_summary()
+
+    assert len(captured) == 1
+    rows = captured[0]
+    assert len(rows) == 2
+    parts = {row[3]: row[4] for row in rows}
+    assert parts["P1"] == 2
+    assert parts["P2"] == 3
+
+    conn = sqlite3.connect(temp_db)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT part_number, total_scanned FROM scan_summary ORDER BY part_number"
+    )
+    result = cur.fetchall()
+    conn.close()
+    assert result == [("P1", 2), ("P2", 3)]


### PR DESCRIPTION
## Summary
- add `DataManager.insert_scan_summaries` for bulk summary inserts
- refactor `ShipperWindow._record_summary` to collect rows and insert once
- test that multiple summaries are inserted in one call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca9432478832686e97baa883bf40a