### PR TITLE
Refactor session creation to occur after waybill selection

### DIFF
--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -26,14 +26,14 @@ class DataManager:
             )
             return cur.fetchone()  # type: ignore[return-value]
 
-    def create_session(self, user_id: int) -> int:
+    def create_session(self, user_id: int, waybill: str = "") -> int:
         """Create a new scan session and return its id."""
         start_time = datetime.utcnow().isoformat()
         with sqlite3.connect(self.db_path) as conn:
             cur = conn.cursor()
             cur.execute(
                 "INSERT INTO scan_sessions (user_id, waybill_number, start_time) VALUES (?, ?, ?)",
-                (user_id, "", start_time),
+                (user_id, waybill, start_time),
             )
             conn.commit()
             session_id = cur.lastrowid

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ This file serves as the program entry point.
 """
 
 from src.ui.admin_interface import start_admin_interface
-from src.ui.login import end_session, prompt_login
+from src.ui.login import prompt_login
 from src.ui.scanner_interface import start_shipper_interface
 
 
@@ -19,15 +19,12 @@ def main() -> None:
             print("Login cancelled")
             break
 
-        session_id, user_id, _username, role = login_info
+        user_id, _username, role = login_info
 
-        try:
-            if role.upper() == "ADMIN":
-                start_admin_interface()
-            else:
-                start_shipper_interface(user_id)
-        finally:
-            end_session(session_id)
+        if role.upper() == "ADMIN":
+            start_admin_interface()
+        else:
+            start_shipper_interface(user_id)
 
 
 if __name__ == "__main__":

--- a/src/ui/login.py
+++ b/src/ui/login.py
@@ -32,9 +32,9 @@ def authenticate_user(
     return DataManager(db_path).authenticate_user(username, password)
 
 
-def create_session(user_id: int, db_path: str = DB_PATH) -> int:
+def create_session(user_id: int, db_path: str = DB_PATH, waybill: str = "") -> int:
     """Create a scan session using :class:`DataManager`."""
-    return DataManager(db_path).create_session(user_id)
+    return DataManager(db_path).create_session(user_id, waybill)
 
 
 def end_session(session_id: int, db_path: str = DB_PATH) -> None:
@@ -44,8 +44,8 @@ def end_session(session_id: int, db_path: str = DB_PATH) -> None:
 
 class LoginWindow(ctk.CTk):
     """
-    Simple login window returning the authenticated user session info.
-    The result tuple is (session_id, user_id, username, role).
+    Simple login window returning the authenticated user information.
+    The result tuple is (user_id, username, role).
     """
 
     def __init__(self, db_path: str = DB_PATH):
@@ -57,7 +57,7 @@ class LoginWindow(ctk.CTk):
 
         self.username_var = ctk.StringVar()
         self.password_var = ctk.StringVar()
-        self.result: Optional[Tuple[int, int, str, str]] = None
+        self.result: Optional[Tuple[int, str, str]] = None
 
         ctk.CTkLabel(self, text="Username:").pack(pady=(20, 5))
         self.username_entry = ctk.CTkEntry(self, textvariable=self.username_var)
@@ -87,14 +87,13 @@ class LoginWindow(ctk.CTk):
 
         logger.info("User %s authenticated", username)
 
-        session_id = create_session(user[0], self.db_path)
-        # store result: (session_id, user_id, username, role)
-        self.result = (session_id, user[0], user[1], user[2])
+        # store result: (user_id, username, role)
+        self.result = (user[0], user[1], user[2])
         self.destroy()
 
-def prompt_login(db_path: str = DB_PATH) -> Optional[Tuple[int, int, str, str]]:
+def prompt_login(db_path: str = DB_PATH) -> Optional[Tuple[int, str, str]]:
     """
-    Display the login window and return (session_id, user_id, username, role)
+    Display the login window and return (user_id, username, role)
     on success, otherwise None.
     """
 

--- a/src/ui/scanner_interface.py
+++ b/src/ui/scanner_interface.py
@@ -53,7 +53,7 @@ class ShipperWindow(ctk.CTk):
         self.csv_path = csv_path
         self.logic = ScannerLogic(self.dm, csv_path)
         self.user_id = user_id
-        self.session_id = self._get_session()
+        self.session_id: Optional[int] = None
         self.bo_df: Optional[pd.DataFrame] = None
 
         self.title("Shipper Interface")
@@ -124,8 +124,8 @@ class ShipperWindow(ctk.CTk):
         self.refresh_progress_table()
 
     # DB helpers -----------------------------------------------------
-    def _get_session(self) -> int:
-        return self.dm.get_or_create_session(self.user_id)
+    def _get_session(self, waybill: str) -> int:
+        return self.dm.create_session(self.user_id, waybill)
 
     def _fetch_waybills(self) -> List[str]:
         return self.dm.fetch_waybills()
@@ -174,19 +174,22 @@ class ShipperWindow(ctk.CTk):
             messagebox.showerror("BO load error", str(exc))
 
     def _insert_event(self, part: str, qty: int, raw: str) -> None:
-        self.dm.insert_scan_event(
-            self.session_id,
-            self.waybill_var.get(),
-            part,
-            qty,
-            raw_scan=raw,
-        )
+        if self.session_id is not None:
+            self.dm.insert_scan_event(
+                self.session_id,
+                self.waybill_var.get(),
+                part,
+                qty,
+                raw_scan=raw,
+            )
 
     def _update_session_waybill(self, waybill: str) -> None:
-        self.dm.update_session_waybill(self.session_id, waybill)
+        if self.session_id is not None:
+            self.dm.update_session_waybill(self.session_id, waybill)
 
     def _finish_session(self) -> None:
-        self.dm.end_session(self.session_id)
+        if self.session_id is not None:
+            self.dm.end_session(self.session_id)
 
         self._record_summary()
         messagebox.showinfo("Waybill finished", "Scan summary saved")
@@ -206,21 +209,25 @@ class ShipperWindow(ctk.CTk):
             allocated = ", ".join(
                 f"{line.subinv}:{line.scanned}" for line in self.lines if line.part == part
             )
-            self.dm.insert_scan_summary(
-                self.session_id,
-                self.waybill_var.get(),
-                self.user_id,
-                part,
-                total,
-                expected,
-                remaining,
-                allocated,
-                datetime.utcnow().date().isoformat(),
-            )
+            if self.session_id is not None:
+                self.dm.insert_scan_summary(
+                    self.session_id,
+                    self.waybill_var.get(),
+                    self.user_id,
+                    part,
+                    total,
+                    expected,
+                    remaining,
+                    allocated,
+                    datetime.utcnow().date().isoformat(),
+                )
 
     # Interface logic ------------------------------------------------
     def load_waybill(self, waybill: str) -> None:
-        self._update_session_waybill(waybill)
+        if self.session_id is None:
+            self.session_id = self._get_session(waybill)
+        else:
+            self._update_session_waybill(waybill)
         scans = self._fetch_scans(waybill)
 
         for widget in self.lines_frame.winfo_children():

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -25,3 +25,18 @@ def test_authenticate_and_session_flow(temp_db):
     end_time = cur.fetchone()[0]
     conn.close()
     assert end_time is not None
+
+
+def test_create_session_with_waybill(temp_db):
+    add_user(temp_db)
+
+    user = login.authenticate_user('test', 'pw', temp_db)
+    assert user is not None
+
+    session_id = login.create_session(user[0], temp_db, 'WB1')
+    conn = sqlite3.connect(temp_db)
+    cur = conn.cursor()
+    cur.execute('SELECT waybill_number FROM scan_sessions WHERE session_id=?', (session_id,))
+    waybill = cur.fetchone()[0]
+    conn.close()
+    assert waybill == 'WB1'

--- a/tests/test_shipper_window.py
+++ b/tests/test_shipper_window.py
@@ -52,6 +52,12 @@ def test_process_scan_allocation(temp_db, monkeypatch):
     assert qty == 6
     assert waybill == 'WB1'
 
+    cur = sqlite3.connect(temp_db).cursor()
+    cur.execute('SELECT waybill_number FROM scan_sessions')
+    session_waybill = cur.fetchone()[0]
+    cur.connection.close()
+    assert session_waybill == 'WB1'
+
 
 def test_waybill_switch_does_not_affect_previous_scans(temp_db, monkeypatch):
     setup_waybill(temp_db)
@@ -89,6 +95,12 @@ def test_waybill_switch_does_not_affect_previous_scans(temp_db, monkeypatch):
     remaining_dict = {wb: rem for wb, _, rem in progress}
     assert remaining_dict['WB1'] == 13
     assert remaining_dict['WB2'] == 2
+
+    cur = sqlite3.connect(temp_db).cursor()
+    cur.execute('SELECT waybill_number FROM scan_sessions WHERE session_id=?', (window.session_id,))
+    current_wb = cur.fetchone()[0]
+    cur.connection.close()
+    assert current_wb == 'WB2'
 
 
 def test_overscan_aborts_without_recording(temp_db, monkeypatch):


### PR DESCRIPTION
## Summary
- sessions are now created with a specified waybill
- login window only authenticates and returns user info
- shipper window creates the session when a waybill is loaded
- update main flow to match new login return value
- extend tests for updated session behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca9451f6c83269a99a783d5c18aad