### PR TITLE
Add part identifier import capability

### DIFF
--- a/data/part_ids.csv
+++ b/data/part_ids.csv
@@ -1,0 +1,4 @@
+part_number,upc_code,qty,description
+P1,UPC1,5,Widget One
+P2,UPC2,1,Widget Two
+P3,,2,Widget Three

--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -252,6 +252,29 @@ class DataManager:
         # not found in DB
         return code, 1
 
+    # --- Part identifiers -----------------------------------------------
+    def insert_part_identifiers(self, rows: Iterable[tuple]) -> int:
+        """Insert multiple part identifier rows and return number inserted."""
+        rows = list(rows)
+        if not rows:
+            return 0
+        query = (
+            "INSERT INTO part_identifiers (part_number, upc_code, qty, description) "
+            "VALUES (?, ?, ?, ?)"
+        )
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.executemany(query, rows)
+            conn.commit()
+            return cur.rowcount if cur.rowcount != -1 else len(rows)
+
+    def clear_part_identifiers(self) -> None:
+        """Remove all rows from ``part_identifiers`` table."""
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("DELETE FROM part_identifiers")
+            conn.commit()
+
     # --- Scan summaries -------------------------------------------------
     def query_scan_summary(
         self,

--- a/src/logic/part_identifier_import.py
+++ b/src/logic/part_identifier_import.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Iterable
+
+from src.config import DB_PATH
+from src.data_manager import DataManager
+
+REQUIRED_COLUMNS = ["part_number", "upc_code", "qty", "description"]
+
+
+def _load_csv(filepath: str | Path) -> list[dict[str, str]]:
+    """Load the CSV file and validate required headers."""
+    path = Path(filepath)
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        missing = [c for c in REQUIRED_COLUMNS if c not in reader.fieldnames]
+        if missing:
+            raise ValueError(f"CSV missing columns: {', '.join(missing)}")
+        rows = [row for row in reader]
+    return rows
+
+
+def _prepare_rows(rows: Iterable[dict[str, str]]) -> list[tuple[str, str, int, str]]:
+    prepared = []
+    for row in rows:
+        part = (row.get("part_number") or "").strip()
+        upc = (row.get("upc_code") or "").strip()
+        qty_str = row.get("qty") or "1"
+        try:
+            qty = int(qty_str)
+        except ValueError:
+            qty = 1
+        description = (row.get("description") or "").strip()
+        if part:
+            prepared.append((part, upc, qty, description))
+    return prepared
+
+
+def import_part_identifiers(filepath: str, db_path: str = DB_PATH) -> int:
+    """Import ``filepath`` and return number of inserted rows."""
+    raw_rows = _load_csv(filepath)
+    rows = _prepare_rows(raw_rows)
+    dm = DataManager(db_path)
+    inserted = dm.insert_part_identifiers(rows)
+    return inserted

--- a/src/ui/admin_interface.py
+++ b/src/ui/admin_interface.py
@@ -12,7 +12,7 @@ from typing import Iterable, List, Optional
 import customtkinter as ctk
 from tkinter import filedialog, messagebox, ttk
 
-from src.logic import waybill_import
+from src.logic import waybill_import, part_identifier_import
 
 from src.config import DB_PATH
 from src.data_manager import DataManager
@@ -29,6 +29,11 @@ logger = logging.getLogger(__name__)
 def import_waybill_file(filepath: str, db_path: str = DB_PATH) -> int:
     """Import ``filepath`` using :func:`waybill_import.import_waybill`."""
     return waybill_import.import_waybill(filepath, db_path)
+
+
+def import_part_identifier_file(filepath: str, db_path: str = DB_PATH) -> int:
+    """Import ``filepath`` using :func:`part_identifier_import.import_part_identifiers`."""
+    return part_identifier_import.import_part_identifiers(filepath, db_path)
 
 
 def get_users(db_path: str = DB_PATH) -> List[tuple[int, str, str]]:
@@ -120,6 +125,13 @@ class AdminWindow(ctk.CTk):
         )
         btn.pack(pady=20)
 
+        id_btn = ctk.CTkButton(
+            self.tab_upload,
+            text="Import Part Identifiers",
+            command=self._choose_part_identifiers,
+        )
+        id_btn.pack(pady=(0, 20))
+
     def _choose_waybill(self) -> None:
         path = filedialog.askopenfilename(
             title="Select Waybill", filetypes=[("Excel files", "*.xlsx *.xls")]
@@ -135,6 +147,24 @@ class AdminWindow(ctk.CTk):
         logger.info("Imported %s with %d lines", path, inserted)
         messagebox.showinfo(
             "Waybill imported", f"{inserted} lines inserted from {Path(path).name}"
+        )
+
+    def _choose_part_identifiers(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Select Part Identifier CSV", filetypes=[("CSV", "*.csv")]
+        )
+        if not path:
+            return
+        try:
+            inserted = import_part_identifier_file(path, self.db_path)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Part identifier import failed: %s", path)
+            messagebox.showerror("Import failed", str(exc))
+            return
+        logger.info("Imported part identifiers %s with %d rows", path, inserted)
+        messagebox.showinfo(
+            "Import complete",
+            f"{inserted} records inserted from {Path(path).name}",
         )
 
     # ---------------------------- User Management ---------------------------

--- a/tests/test_part_identifier_import.py
+++ b/tests/test_part_identifier_import.py
@@ -1,0 +1,24 @@
+import sqlite3
+from src.logic import part_identifier_import
+
+
+def test_import_part_identifiers(temp_db, tmp_path):
+    csv_path = tmp_path / "ids.csv"
+    csv_content = (
+        "part_number,upc_code,qty,description\n"
+        "P1,UPC1,5,Desc1\n"
+        "P2,UPC2,1,Desc2\n"
+    )
+    csv_path.write_text(csv_content)
+
+    inserted = part_identifier_import.import_part_identifiers(str(csv_path), temp_db)
+    assert inserted == 2
+
+    conn = sqlite3.connect(temp_db)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT part_number, upc_code, qty, description FROM part_identifiers ORDER BY part_number"
+    )
+    rows = [(r[0], r[1], int(r[2]), r[3]) for r in cur.fetchall()]
+    conn.close()
+    assert rows == [("P1", "UPC1", 5, "Desc1"), ("P2", "UPC2", 1, "Desc2")]


### PR DESCRIPTION
## Summary
- support importing part identifier CSVs
- extend DataManager with helper methods for part identifiers
- expose import option in admin UI
- add sample part_ids.csv
- test part identifier import logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685062da59388326b41616751146afbe