### PR TITLE
Add database viewer feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,10 @@ Administrators can load these mappings from a CSV file:
    - `upc_code`
    - `qty`
    - `description`
+
+## Database Viewer
+
+The **Admin** window now includes a *Database Viewer* tab. It lists all tables
+in the SQLite database and lets you inspect and edit their contents. Selecting a
+table shows its rows with **Edit** and **Delete** actions. Edits and deletions
+are wrapped in a transaction so you can cancel changes before committing.

--- a/tests/test_data_manager_generic.py
+++ b/tests/test_data_manager_generic.py
@@ -1,0 +1,33 @@
+import sqlite3
+
+from src.data_manager import DataManager
+
+
+def test_table_listing(temp_db):
+    dm = DataManager(temp_db)
+    tables = dm.fetch_table_names()
+    assert 'users' in tables
+    assert 'waybill_lines' in tables
+
+
+def test_row_crud(temp_db):
+    dm = DataManager(temp_db)
+    conn = sqlite3.connect(temp_db)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO users (username, password_hash, role) VALUES ('u1','h','ADMIN')"
+    )
+    conn.commit()
+    conn.close()
+
+    cols, rows = dm.fetch_rows('users')
+    assert cols[1:] == ['user_id', 'username', 'password_hash', 'role'] or cols[0] == 'rowid'
+    pk = rows[0][0]
+
+    dm.update_row('users', pk, {'username': 'u2'})
+    cols, rows = dm.fetch_rows('users')
+    assert rows[0][cols.index('username')] == 'u2'
+
+    dm.delete_row('users', pk)
+    _, rows = dm.fetch_rows('users')
+    assert rows == []


### PR DESCRIPTION
## Summary
- implement generic database helpers in `DataManager`
- add a Database Viewer tab in the admin UI
- enable editing and deleting rows with transactional cancel/undo
- document the new feature
- cover new methods with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a034640883268235533939b0dc67