### PR TITLE
Add status tracking for waybill lines

### DIFF
--- a/database/init_db.py
+++ b/database/init_db.py
@@ -1,6 +1,13 @@
 import sqlite3
+import logging
+
+from src.logging_utils import setup_logging
 
 #def initialize_database(db_path='receiving_tracker.db', schema_path='database/schema.sql'):
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
 def initialize_database(
     db_path: str = "receiving_tracker.db",
     schema_path: str = "database/schema.sql",
@@ -13,7 +20,7 @@ def initialize_database(
     cursor.executescript(schema)
     conn.commit()
     conn.close()
-    print(f"Database created and initialized at '{db_path}'")
+    logger.info("Database created and initialized at '%s'", db_path)
 
 if __name__ == '__main__':
     initialize_database()

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -24,7 +24,8 @@ CREATE TABLE IF NOT EXISTS waybill_lines (
     locator TEXT,
     description TEXT,
     item_cost REAL,
-    date TEXT NOT NULL
+    date TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'ACTIVE'
 );
 
 -- scan_sessions

--- a/src/ui/scanner_interface.py
+++ b/src/ui/scanner_interface.py
@@ -141,7 +141,7 @@ class ShipperWindow(ctk.CTk):
         return self.dm.create_session(self.user_id, waybill)
 
     def _fetch_waybills(self) -> List[str]:
-        return self.dm.fetch_waybills()
+        return self.dm.fetch_active_waybills()
 
     def _fetch_scans(self, waybill: str) -> Dict[str, int]:
         return self.dm.fetch_scans(waybill)
@@ -202,6 +202,7 @@ class ShipperWindow(ctk.CTk):
 
     def _finish_session(self) -> None:
         self.record_partial_summary()
+        self.dm.mark_waybill_completed(self.waybill_var.get())
         messagebox.showinfo("Waybill finished", "Scan summary saved")
         self.destroy()
 

--- a/tests/test_waybill_status.py
+++ b/tests/test_waybill_status.py
@@ -1,0 +1,30 @@
+import sqlite3
+from src.data_manager import DataManager
+
+
+def setup_waybill(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
+        " VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '2024-01-01')"
+    )
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
+        " VALUES ('WB2', 'P2', 3, 'DRV-RM', '', '', 0, '2024-01-01')"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_waybill_complete_flow(temp_db):
+    setup_waybill(temp_db)
+    dm = DataManager(temp_db)
+
+    active = dm.fetch_active_waybills()
+    assert sorted(active) == ['WB1', 'WB2']
+
+    dm.mark_waybill_completed('WB1')
+
+    active_after = dm.fetch_active_waybills()
+    assert active_after == ['WB2']


### PR DESCRIPTION
## Summary
- track active/completed waybills with new `status` column
- log initialization steps when creating a database
- extend `DataManager` with helpers for status changes
- update scanner UI to mark a waybill completed
- test waybill completion workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c1dfd30c83268efaec1559d68804