### PR TITLE
Track terminated waybills

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -64,3 +64,11 @@ CREATE TABLE IF NOT EXISTS scan_summary (
     FOREIGN KEY(session_id) REFERENCES scan_sessions(session_id),
     FOREIGN KEY(user_id) REFERENCES users(user_id)
 );
+
+-- terminated waybills
+CREATE TABLE IF NOT EXISTS terminated_waybills (
+    waybill_number TEXT PRIMARY KEY,
+    terminated_at TEXT NOT NULL,
+    user_id INTEGER,
+    FOREIGN KEY(user_id) REFERENCES users(user_id)
+);

--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import sqlite3
 from datetime import datetime
 from typing import Dict, Iterable, List, Optional, Tuple
 
 from .config import DB_PATH
+
+logger = logging.getLogger(__name__)
 
 
 class DataManager:
@@ -178,7 +181,10 @@ class DataManager:
     def fetch_waybills(self) -> List[str]:
         with sqlite3.connect(self.db_path) as conn:
             cur = conn.cursor()
-            cur.execute("SELECT DISTINCT waybill_number FROM waybill_lines")
+            cur.execute(
+                "SELECT DISTINCT waybill_number FROM waybill_lines "
+                "WHERE waybill_number NOT IN (SELECT waybill_number FROM terminated_waybills)"
+            )
             rows = [r[0] for r in cur.fetchall()]
         return rows
 
@@ -196,11 +202,15 @@ class DataManager:
         with sqlite3.connect(self.db_path) as conn:
             cur = conn.cursor()
             cur.execute(
-                "SELECT waybill_number, SUM(qty_total) FROM waybill_lines GROUP BY waybill_number"
+                "SELECT waybill_number, SUM(qty_total) FROM waybill_lines "
+                "WHERE waybill_number NOT IN (SELECT waybill_number FROM terminated_waybills) "
+                "GROUP BY waybill_number"
             )
             totals = {row[0]: int(row[1]) for row in cur.fetchall()}
             cur.execute(
-                "SELECT waybill_number, SUM(scanned_qty) FROM scan_events GROUP BY waybill_number"
+                "SELECT waybill_number, SUM(scanned_qty) FROM scan_events "
+                "WHERE waybill_number NOT IN (SELECT waybill_number FROM terminated_waybills) "
+                "GROUP BY waybill_number"
             )
             scanned = {row[0]: int(row[1]) for row in cur.fetchall()}
         progress = []
@@ -220,6 +230,18 @@ class DataManager:
             )
             rows = [(int(r[0]), r[1], int(r[2]), r[3]) for r in cur.fetchall()]
         return rows
+
+    def mark_waybill_terminated(self, waybill: str, user_id: int) -> None:
+        """Record that ``waybill`` processing was terminated by ``user_id``."""
+        timestamp = datetime.utcnow().isoformat()
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT OR REPLACE INTO terminated_waybills (waybill_number, terminated_at, user_id) VALUES (?, ?, ?)",
+                (waybill, timestamp, user_id),
+            )
+            conn.commit()
+        logger.info("Waybill %s terminated by user %s", waybill, user_id)
 
     def insert_scan_event(
         self,

--- a/tests/test_waybill_termination.py
+++ b/tests/test_waybill_termination.py
@@ -1,0 +1,35 @@
+import sqlite3
+
+from src.data_manager import DataManager
+
+
+def setup_waybill(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
+        " VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '2024-01-01')"
+    )
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
+        " VALUES ('WB2', 'P2', 3, 'DRV-RM', '', '', 0, '2024-01-01')"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_mark_waybill_terminated_excludes_from_fetch(temp_db):
+    setup_waybill(temp_db)
+    dm = DataManager(temp_db)
+    dm.mark_waybill_terminated('WB2', 1)
+    waybills = dm.fetch_waybills()
+    assert waybills == ['WB1']
+
+
+def test_get_waybill_progress_excludes_terminated(temp_db):
+    setup_waybill(temp_db)
+    dm = DataManager(temp_db)
+    dm.mark_waybill_terminated('WB2', 1)
+    progress = dm.get_waybill_progress()
+    wb_list = [wb for wb, _, _ in progress]
+    assert wb_list == ['WB1']


### PR DESCRIPTION
## Summary
- create `terminated_waybills` table
- exclude terminated waybills when listing and reporting progress
- provide `mark_waybill_terminated` method with logging
- test termination behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850cc6daefc8326a7eecb012b0a4cab