### PR TITLE
Add date filter for waybills and UI updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,8 @@ The **Admin** window now includes a *Database Viewer* tab. It lists all tables
 in the SQLite database and lets you inspect and edit their contents. Selecting a
 table shows its rows with **Edit** and **Delete** actions. Edits and deletions
 are wrapped in a transaction so you can cancel changes before committing.
+
+## Today's Waybills
+
+The shipper interface now lists only the waybills dated today when it starts.
+Click **Show All Waybills** to display previous days as well.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -101,6 +101,7 @@ These tables together:
 
 ### For SHIPPER
 - Minimal clicks
+- Waybill list filtered to today's date with a **Show All Waybills** option
 - Manual part number input allowed
 - Quantity input before scanning (default = 1, resets after each scan)
 - Display part info after scan

--- a/tests/test_partial_cleanup.py
+++ b/tests/test_partial_cleanup.py
@@ -2,12 +2,16 @@ import sqlite3
 import pytest
 
 
+from datetime import datetime
+
+
 def setup_waybill(db_path: str) -> None:
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
+    today = datetime.utcnow().date().isoformat()
     cur.execute(
         "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
-        " VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '2024-01-01')"
+        f" VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}')"
     )
     conn.commit()
     conn.close()

--- a/tests/test_shipper_window.py
+++ b/tests/test_shipper_window.py
@@ -4,20 +4,24 @@ import types
 import pytest
 
 
+from datetime import datetime
+
+
 def setup_waybill(db_path):
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
+    today = datetime.utcnow().date().isoformat()
     cur.execute(
         "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
-        " VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '2024-01-01')"
+        f" VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}')"
     )
     cur.execute(
         "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
-        " VALUES ('WB1', 'P1', 10, 'DRV-RM', '', '', 0, '2024-01-01')"
+        f" VALUES ('WB1', 'P1', 10, 'DRV-RM', '', '', 0, '{today}')"
     )
     cur.execute(
         "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
-        " VALUES ('WB2', 'P1', 5, 'DRV-AMO', '', '', 0, '2024-01-01')"
+        f" VALUES ('WB2', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}')"
     )
     conn.commit()
     conn.close()

--- a/tests/test_summary_insert.py
+++ b/tests/test_summary_insert.py
@@ -2,16 +2,20 @@ import sqlite3
 import pytest
 
 
+from datetime import datetime
+
+
 def setup_waybill_multi(db_path: str) -> None:
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
+    today = datetime.utcnow().date().isoformat()
     cur.execute(
         "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
-        " VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '2024-01-01')"
+        f" VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}')"
     )
     cur.execute(
         "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
-        " VALUES ('WB1', 'P2', 10, 'DRV-RM', '', '', 0, '2024-01-01')"
+        f" VALUES ('WB1', 'P2', 10, 'DRV-RM', '', '', 0, '{today}')"
     )
     conn.commit()
     conn.close()

--- a/tests/test_waybill_date_filter.py
+++ b/tests/test_waybill_date_filter.py
@@ -1,0 +1,33 @@
+import sqlite3
+
+from src.data_manager import DataManager
+
+
+def setup_waybills(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date) "
+        "VALUES ('WB1', 'P1', 1, 'DRV-AMO', '', '', 0, '2024-01-01')"
+    )
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date) "
+        "VALUES ('WB2', 'P1', 1, 'DRV-AMO', '', '', 0, '2024-01-02')"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_fetch_waybills_date_filter(temp_db):
+    setup_waybills(temp_db)
+    dm = DataManager(temp_db)
+    assert dm.fetch_waybills('2024-01-01') == ['WB1']
+    assert sorted(dm.fetch_waybills()) == ['WB1', 'WB2']
+
+
+def test_get_waybill_dates(temp_db):
+    setup_waybills(temp_db)
+    dm = DataManager(temp_db)
+    dates = dm.get_waybill_dates()
+    assert dates == {'WB1': '2024-01-01', 'WB2': '2024-01-02'}
+


### PR DESCRIPTION
## Summary
- extend DataManager with optional date filtering and new `get_waybill_dates`
- filter Shipper interface waybill list to today's date by default
- allow showing all waybills via button
- display waybill dates and highlight older pending ones
- document the new behaviour
- add tests for date filtering and adjust existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685164b1dc2c8326b464a56c1417025d