### PR TITLE
Handle missing waybill dates

### DIFF
--- a/src/ui/scanner_interface.py
+++ b/src/ui/scanner_interface.py
@@ -63,6 +63,8 @@ class ShipperWindow(ctk.CTk):
         today = datetime.utcnow().date().isoformat()
         self.waybills = self._fetch_waybills(today)
         if not self.waybills:
+            self.waybills = self._fetch_waybills(None)
+        if not self.waybills:
             messagebox.showinfo("Info", "No active waybills in database")
             self.destroy()
             return
@@ -459,6 +461,8 @@ def start_shipper_interface(
 ) -> None:
     """Launch the shipper interface for ``user_id``."""
     app = ShipperWindow(user_id, db_path, csv_path)
+    if not app.waybills:
+        return
     try:
         app.mainloop()
     finally:

--- a/tests/test_shipper_window.py
+++ b/tests/test_shipper_window.py
@@ -201,3 +201,26 @@ def test_manual_logout_ends_session(temp_db, monkeypatch):
     end_time = cur.fetchone()[0]
     conn.close()
     assert end_time is not None
+
+
+def test_start_interface_with_blank_date(temp_db, monkeypatch):
+    conn = sqlite3.connect(temp_db)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date) "
+        "VALUES ('WBX', 'P1', 1, 'DRV-AMO', '', '', 0, '')"
+    )
+    conn.commit()
+    conn.close()
+
+    from src.ui import scanner_interface
+
+    monkeypatch.setattr(
+        scanner_interface.ShipperWindow,
+        'mainloop',
+        lambda self: None,
+        raising=False,
+    )
+
+    # Should not raise TclError when waybill date missing
+    scanner_interface.start_shipper_interface(1, temp_db)


### PR DESCRIPTION
## Summary
- better handle missing waybill dates when starting shipper interface
- skip `mainloop` when there are no waybills
- test that blank dates don't crash shipper interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851711ec664832683e1b70a1f723a6b