### PR TITLE
Handle waybill import date for 'today' logic

### DIFF
--- a/database/migrate.py
+++ b/database/migrate.py
@@ -25,6 +25,12 @@ def add_waybill_number_column(db_path: str = "receiving_tracker.db") -> None:
         )
         conn.commit()
 
+    cur.execute("PRAGMA table_info(waybill_lines)")
+    columns = [row[1] for row in cur.fetchall()]
+    if "import_date" not in columns:
+        cur.execute("ALTER TABLE waybill_lines ADD COLUMN import_date TEXT NOT NULL DEFAULT (DATE('now'))")
+        conn.commit()
+
     conn.close()
 
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -25,7 +25,8 @@ CREATE TABLE IF NOT EXISTS waybill_lines (
     locator TEXT,
     description TEXT,
     item_cost REAL,
-    date TEXT NOT NULL
+    date TEXT NOT NULL,
+    import_date TEXT NOT NULL DEFAULT (DATE('now'))
 );
 
 -- scan_sessions

--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -223,6 +223,17 @@ class DataManager:
             rows = {row[0]: row[1] for row in cur.fetchall()}
         return rows
 
+    def get_waybill_import_dates(self) -> Dict[str, str]:
+        """Return mapping of active waybills to their import date."""
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT waybill_number, import_date FROM waybill_lines "
+                "WHERE waybill_number NOT IN (SELECT waybill_number FROM terminated_waybills)"
+            )
+            rows = {row[0]: row[1] for row in cur.fetchall()}
+        return rows
+
     def fetch_scans(self, waybill: str) -> Dict[str, int]:
         with sqlite3.connect(self.db_path) as conn:
             cur = conn.cursor()

--- a/src/logic/waybill_import.py
+++ b/src/logic/waybill_import.py
@@ -9,6 +9,7 @@ from typing import Iterable
 import pandas as pd
 
 from src.config import DB_PATH
+from datetime import datetime
 
 #DB_PATH = "receiving_tracker.db"
 
@@ -60,8 +61,8 @@ def _insert_rows(rows: Iterable[tuple], db_path: str) -> int:
     """Insert rows into waybill_lines and return number inserted."""
     query = (
         "INSERT INTO waybill_lines (waybill_number, part_number, qty_total,"
-        " subinv, locator, description, item_cost, date) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        " subinv, locator, description, item_cost, date, import_date) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
     )
     rows = list(rows)
     with sqlite3.connect(db_path) as conn:
@@ -85,6 +86,7 @@ def import_waybill(filepath: str, db_path: str = DB_PATH) -> int:
             row["DESCRIPTION"],
             row["ITEM_COSTS"],
             row["SHIP_DATE"],
+            datetime.utcnow().date().isoformat(),
         )
         for _, row in df.iterrows()
     ]

--- a/tests/test_partial_cleanup.py
+++ b/tests/test_partial_cleanup.py
@@ -2,16 +2,20 @@ import sqlite3
 import pytest
 
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 def setup_waybill(db_path: str) -> None:
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
     today = datetime.utcnow().date().isoformat()
+    target = datetime.utcnow().date() - timedelta(days=1)
+    while target.weekday() >= 5:
+        target -= timedelta(days=1)
+    import_date = target.isoformat()
     cur.execute(
-        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
-        f" VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}')"
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date, import_date)"
+        f" VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}', '{import_date}')"
     )
     conn.commit()
     conn.close()

--- a/tests/test_shipper_window.py
+++ b/tests/test_shipper_window.py
@@ -4,7 +4,7 @@ import types
 import pytest
 
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from src.data_manager import DataManager
 
 
@@ -12,17 +12,21 @@ def setup_waybill(db_path):
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
     today = datetime.utcnow().date().isoformat()
+    target = datetime.utcnow().date() - timedelta(days=1)
+    while target.weekday() >= 5:
+        target -= timedelta(days=1)
+    import_date = target.isoformat()
     cur.execute(
-        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
-        f" VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}')"
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date, import_date)"
+        f" VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}', '{import_date}')"
     )
     cur.execute(
-        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
-        f" VALUES ('WB1', 'P1', 10, 'DRV-RM', '', '', 0, '{today}')"
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date, import_date)"
+        f" VALUES ('WB1', 'P1', 10, 'DRV-RM', '', '', 0, '{today}', '{import_date}')"
     )
     cur.execute(
-        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
-        f" VALUES ('WB2', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}')"
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date, import_date)"
+        f" VALUES ('WB2', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}', '{import_date}')"
     )
     conn.commit()
     conn.close()
@@ -293,9 +297,9 @@ def test_today_menu_empty_and_status_label(temp_db, monkeypatch):
     cur = conn.cursor()
     old_date = '2000-01-01'
     cur.execute(
-        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
-        " VALUES ('OLDWB', 'P1', 1, 'DRV-AMO', '', '', 0, ?)",
-        (old_date,),
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date, import_date)"
+        " VALUES ('OLDWB', 'P1', 1, 'DRV-AMO', '', '', 0, ?, ?)",
+        (old_date, old_date),
     )
     conn.commit()
     conn.close()

--- a/tests/test_summary_insert.py
+++ b/tests/test_summary_insert.py
@@ -2,20 +2,24 @@ import sqlite3
 import pytest
 
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 def setup_waybill_multi(db_path: str) -> None:
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
     today = datetime.utcnow().date().isoformat()
+    target = datetime.utcnow().date() - timedelta(days=1)
+    while target.weekday() >= 5:
+        target -= timedelta(days=1)
+    import_date = target.isoformat()
     cur.execute(
-        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
-        f" VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}')"
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date, import_date)"
+        f" VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}', '{import_date}')"
     )
     cur.execute(
-        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date)"
-        f" VALUES ('WB1', 'P2', 10, 'DRV-RM', '', '', 0, '{today}')"
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date, import_date)"
+        f" VALUES ('WB1', 'P2', 10, 'DRV-RM', '', '', 0, '{today}', '{import_date}')"
     )
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Summary
- store the import date in `waybill_lines`
- migrate existing databases with new column
- expose `DataManager.get_waybill_import_dates`
- write import date via `waybill_import`
- base "today" selection on last working day and import date
- adjust progress table color logic
- update tests for new column

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851f6a2499c83268fffd6f379b86a88