### PR TITLE
Fix import date comparisons

### DIFF
--- a/src/ui/scanner_interface.py
+++ b/src/ui/scanner_interface.py
@@ -76,7 +76,7 @@ class ShipperWindow(ctk.CTk):
         today = datetime.utcnow().date()
         all_wbs = self._fetch_waybills(None)
         import_dates = self.dm.get_waybill_import_dates()
-        target = _last_working_day(today)
+        target = today
         self.today_waybills = []
         for wb in all_wbs:
             date_str = import_dates.get(wb)
@@ -228,7 +228,7 @@ class ShipperWindow(ctk.CTk):
             messagebox.showinfo("Info", "No active waybills in database")
             return
         import_dates = self.dm.get_waybill_import_dates()
-        target = _last_working_day(today)
+        target = today
         self.today_waybills = []
         for wb in all_wbs:
             date_str = import_dates.get(wb)
@@ -276,9 +276,8 @@ class ShipperWindow(ctk.CTk):
             lbl.grid(row=0, column=idx, sticky="w")
 
         rows = self._get_waybill_progress()
-        dates = self.dm.get_waybill_dates()
+        dates = self.dm.get_waybill_import_dates()
         today = datetime.utcnow().date()
-        target = _last_working_day(today)
         for row_idx, (waybill, total, remaining) in enumerate(rows, start=1):
             date_str = dates.get(waybill, "")
             try:
@@ -286,7 +285,7 @@ class ShipperWindow(ctk.CTk):
             except Exception:
                 parsed = None
             color = (
-                "orange" if parsed and parsed < target and remaining > 0 else None
+                "orange" if parsed and parsed < today and remaining > 0 else None
             )
             kwargs = dict(
                 text=f"{waybill} ({date_str})", width=120, anchor="w", font=cell_font
@@ -331,7 +330,7 @@ class ShipperWindow(ctk.CTk):
         incompletes = self.dm.fetch_incomplete_waybills()
         import_dates = self.dm.get_waybill_import_dates()
         today = datetime.utcnow().date()
-        target = _last_working_day(today)
+        target = today
         old = [wb for wb in incompletes if import_dates.get(wb) != target]
         self._load_list(old, "Incomplete waybills")
 

--- a/tests/test_partial_cleanup.py
+++ b/tests/test_partial_cleanup.py
@@ -9,10 +9,7 @@ def setup_waybill(db_path: str) -> None:
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
     today = datetime.utcnow().date().isoformat()
-    target = datetime.utcnow().date() - timedelta(days=1)
-    while target.weekday() >= 5:
-        target -= timedelta(days=1)
-    import_date = target.isoformat()
+    import_date = today
     cur.execute(
         "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date, import_date)"
         f" VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}', '{import_date}')"

--- a/tests/test_shipper_window.py
+++ b/tests/test_shipper_window.py
@@ -12,10 +12,7 @@ def setup_waybill(db_path):
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
     today = datetime.utcnow().date().isoformat()
-    target = datetime.utcnow().date() - timedelta(days=1)
-    while target.weekday() >= 5:
-        target -= timedelta(days=1)
-    import_date = target.isoformat()
+    import_date = today
     cur.execute(
         "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date, import_date)"
         f" VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}', '{import_date}')"
@@ -262,8 +259,16 @@ def test_progress_table_highlighting(temp_db, monkeypatch):
     conn = sqlite3.connect(temp_db)
     cur = conn.cursor()
     old_date = '2024-01-01'
-    cur.execute("INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date) VALUES ('OLD1','P1',1,'DRV-AMO','','',0,?)", (old_date,))
-    cur.execute("INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date) VALUES ('OLD2','P1',1,'DRV-AMO','','',0,?)", (old_date,))
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date, import_date)"
+        " VALUES ('OLD1','P1',1,'DRV-AMO','','',0,?, ?)",
+        (old_date, old_date),
+    )
+    cur.execute(
+        "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date, import_date)"
+        " VALUES ('OLD2','P1',1,'DRV-AMO','','',0,?, ?)",
+        (old_date, old_date),
+    )
     conn.commit()
     conn.close()
 

--- a/tests/test_summary_insert.py
+++ b/tests/test_summary_insert.py
@@ -9,10 +9,7 @@ def setup_waybill_multi(db_path: str) -> None:
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
     today = datetime.utcnow().date().isoformat()
-    target = datetime.utcnow().date() - timedelta(days=1)
-    while target.weekday() >= 5:
-        target -= timedelta(days=1)
-    import_date = target.isoformat()
+    import_date = today
     cur.execute(
         "INSERT INTO waybill_lines (waybill_number, part_number, qty_total, subinv, locator, description, item_cost, date, import_date)"
         f" VALUES ('WB1', 'P1', 5, 'DRV-AMO', '', '', 0, '{today}', '{import_date}')"


### PR DESCRIPTION
## Summary
- compare waybills to today's import date
- highlight older waybills based on import date
- update tests for new import date logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685200c2b66c8326b4fb3aa3c6d7648b