### PR TITLE
Fix filtering of incomplete waybills

### DIFF
--- a/src/ui/scanner_interface.py
+++ b/src/ui/scanner_interface.py
@@ -330,8 +330,15 @@ class ShipperWindow(ctk.CTk):
         incompletes = self.dm.fetch_incomplete_waybills()
         import_dates = self.dm.get_waybill_import_dates()
         today = datetime.utcnow().date()
-        target = today
-        old = [wb for wb in incompletes if import_dates.get(wb) != target]
+        old: list[str] = []
+        for wb in incompletes:
+            date_str = import_dates.get(wb)
+            try:
+                imp = datetime.fromisoformat(date_str).date() if date_str else None
+            except Exception:
+                imp = None
+            if imp != today:
+                old.append(wb)
         self._load_list(old, "Incomplete waybills")
 
     def load_bo_report(self, filepath: str) -> None:

--- a/tests/test_shipper_window.py
+++ b/tests/test_shipper_window.py
@@ -360,3 +360,18 @@ def test_status_label_updates(temp_db, monkeypatch):
 
     window._load_all_today()
     assert window.list_status._text == "Today's waybills"
+
+
+def test_load_all_incomplete_excludes_today(temp_db, monkeypatch):
+    setup_waybill(temp_db)
+
+    from src.ui import scanner_interface
+
+    monkeypatch.setattr(scanner_interface.ShipperWindow, '_finish_session', lambda self: None)
+
+    window = scanner_interface.ShipperWindow(user_id=1, db_path=temp_db)
+
+    window._load_all_incomplete()
+
+    assert window.lines == []
+    assert window.waybill_var.get() == ""


### PR DESCRIPTION
## Summary
- parse import dates when showing incomplete waybills
- ensure today's waybills aren't shown in the incomplete list
- test that today's incomplete waybills are excluded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685204e06640832682ecd5629ce2caec